### PR TITLE
Windows SIGPIPE Fix

### DIFF
--- a/arweave/transaction_uploader.py
+++ b/arweave/transaction_uploader.py
@@ -10,9 +10,11 @@ from .utils import *
 from .merkle import validate_path, CHUNK_SIZE
 from .arweave_lib import API_URL
 
-from signal import signal, SIGPIPE, SIG_DFL
-
-signal(SIGPIPE, SIG_DFL)
+try:
+    from signal import signal, SIGPIPE, SIG_DFL
+    signal(SIGPIPE, SIG_DFL)
+except ImportError:  # If SIGPIPE is not available (win32),
+    pass
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
I'm currently using the latest version of arweave-python-client on Python 3.7.9 (Python for Unity, version 4.0.0.-exp-.5) with Unity 2020.3.12f1, on Windows 10

Error: PythonException: ImportError : cannot import name 'SIGPIPE' from 'signal' 

SIGPIPE is not supported on Windows so we ignore it if it can't be loaded.