### PR TITLE
fix: not overwrite reward param provided  by user

### DIFF
--- a/arweave/arweave_lib.py
+++ b/arweave/arweave_lib.py
@@ -201,8 +201,10 @@ class Transaction(object):
             self.id = self.id.decode()
 
     def get_signature_data(self):
-        self.reward = self.get_reward(self.data_size, target_address=self.target if len(self.target) > 0 else None)
-
+        reward = self.get_reward(self.data_size, target_address=self.target if len(self.target) > 0 else None)
+        if not self.reward or int(self.reward) < int(reward):
+            self.reward = reward
+            
         if int(self.data_size) > 0 and self.data_root == "" and not self.uses_uploader:
             if type(self.data) == str:
                 root_hash = compute_root_hash(io.BytesIO(base64url_decode(self.data.encode('utf-8'))))


### PR DESCRIPTION
when user provide reward param in Transaction's init() function (eg: t = arweave.Transaction(wallet, data='123', reward='10000000000')), it will always be overwrited.